### PR TITLE
Bump up mysql-connector-python version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@ Flask==3.0.3
 Werkzeug==3.0.3
 
 # To match the AWS RDS MySQL server 8.0.23, returned by the SELECT VERSION() query.
-mysql-connector-python==8.0.23
+mysql-connector-python==9.1.0
 
 # The commons package requires requests>=2.22.0
 requests==2.32.3

--- a/src/ukv_worker.py
+++ b/src/ukv_worker.py
@@ -215,7 +215,7 @@ class UserKeyValueWorker:
     what was presented in the Request.  That cannot be discerned from the value-only return of this method,
     like it can be using find_named_key_values().
     '''
-    def get_key_value(self, req: Request, valid_key: Annotated[str, 50]) -> str:
+    def get_key_value(self, req: Request, valid_key: Annotated[str, 50]) -> bytearray:
 
         globus_id = self._get_globus_id_for_request(req)
         if isinstance(globus_id, Response):


### PR DESCRIPTION
Bump mysql-connector-python to version 9.1.0. Deal with bytearray() being returned from call to fetchone() by expecting it for the UTF-8 table ukv-api uses, and decode() to a string.