### PR TITLE
Defer endpoint access to AWS Gateway to allow all consortium read members

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -14,9 +14,6 @@ import ukv_exceptions as ukvEx
 
 from flask import Flask, request, jsonify, make_response, Request
 
-# HuBMAP commons
-from hubmap_commons.hm_auth import secured
-
 # Root logger configuration
 global logger
 
@@ -106,6 +103,7 @@ def status():
 """
 An endpoint to create or update a key/value pair for the authenticated user.
 The value is valid JSON attached to the HTTP Request.
+Endpoint access for an authenticated user is managed in the AWS Gateway.
 
 Parameters
 ----------
@@ -130,7 +128,6 @@ HTTP 500 Response
 An unexpected error in the server, including unexpected problems with the data store.
 """
 @app.route(rule='/user/keys/<key>', methods=["PUT"])
-@secured(has_write=True)
 def upsert_key_value(key: Annotated[str, 50]):
     global ukv_worker
 
@@ -310,6 +307,7 @@ are specified in the JSON payload of the HTTP Request.  The JSON body is a list 
 dictionary for each key/value pair for the user to store.  Each key must be valid, and each value must
 be valid JSON itself. No key/value pair is stored unless all key/value pairs are stored, as indicated
 by an HTTP 200 Response.
+Endpoint access for an authenticated user is managed in the AWS Gateway.
 
 Parameters
 ----------
@@ -335,7 +333,6 @@ HTTP 500 Response
 An unexpected error in the server, including unexpected problems with the data store.
 """
 @app.route(rule='/user/keys', methods=["PUT"])
-@secured(has_write=True)
 def upsert_key_values():
     global ukv_worker
 
@@ -353,6 +350,7 @@ def upsert_key_values():
 """
 An endpoint to delete a key/value pair for the authenticated user.
 On success returns an HTTP 200 Response.
+Endpoint access for an authenticated user is managed in the AWS Gateway.
 
 Parameters
 ----------
@@ -376,7 +374,6 @@ HTTP 500 Response
 An unexpected error in the server, including unexpected problems with the data store.
 """
 @app.route(rule='/user/keys/<key>', methods=["DELETE"])
-@secured(has_write=True)
 def delete_key_value(key: Annotated[str, 50]):
     global ukv_worker
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@ Flask==3.0.3
 Werkzeug==3.0.3
 
 # To match the AWS RDS MySQL server 8.0.23, returned by the SELECT VERSION() query.
-mysql-connector-python==8.0.23
+mysql-connector-python==9.1.0
 
 # The commons package requires requests>=2.22.0
 requests==2.32.3

--- a/src/ukv_worker.py
+++ b/src/ukv_worker.py
@@ -215,7 +215,7 @@ class UserKeyValueWorker:
     what was presented in the Request.  That cannot be discerned from the value-only return of this method,
     like it can be using find_named_key_values().
     '''
-    def get_key_value(self, req: Request, valid_key: Annotated[str, 50]) -> str:
+    def get_key_value(self, req: Request, valid_key: Annotated[str, 50]) -> bytearray:
 
         globus_id = self._get_globus_id_for_request(req)
         if isinstance(globus_id, Response):

--- a/user-key-value-api-spec.yaml
+++ b/user-key-value-api-spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: 'The HuBMAP User Key/Value API is a RESTful web service with create/update, read, and delete operations for key/value pairs associated with an authorized user, which persist in a backend data store.'
-  version: 1.0.0
+  version: 1.0.1
   title: HuBMAP UKV API
   contact:
     name: HuBMAP Help Desk
@@ -90,6 +90,10 @@ paths:
           description: The key was created or updated with the value of the JSON in the Request and the Globus ID of the bearer token. The Response has a JSON body with one object with a "message" key, and the associated value confirms the successful operation
         '400':
           description: The create or update operation failed, so nothing changed in the data store. The Response has a JSON body with one object with an "error" key, and the associated value describes the problem.  Typical causes are keys which have whitespace or disallowed characters, keys which are too long, and invalid JSON in the Request.
+        '401':
+          description: The user provided Globus token has expired or the user did not supply a valid token.
+        '403':
+          description: The user provided Globus token does not have the desired membership permission to access this resource.
         '500':
           description: An internal error occurred, causing the operation to fail, so nothing changed in the data store. Typical of unexpected problems and monitored by IT staff.
     get:
@@ -106,6 +110,10 @@ paths:
           description: The key in the Request parameter was read for the Globus ID of the bearer token. The Response has a JSON body which is the complete value stored for the user's key
         '400':
           description: The read operation failed. The Response has a JSON body with one object with an "error" key, and the associated value describes the problem.  Typical causes are keys which have whitespace or disallowed characters and keys which are too long.
+        '401':
+          description: The user provided Globus token has expired or the user did not supply a valid token.
+        '403':
+          description: The user provided Globus token does not have the desired membership permission to access this resource.
         '404':
           description: The read operation failed because the key was not found for the user. The Response has a JSON body with one object with an "error" key, and the associated value describes the problem.
         '500':
@@ -124,6 +132,10 @@ paths:
           description: The key in the Request parameter and its value were deleted for the Globus ID of the bearer token.
         '400':
           description: The delete operation failed. The Response has a JSON body with one object with an "error" key, and the associated value describes the problem.  Typical causes are keys which have whitespace or disallowed characters and keys which are too long.
+        '401':
+          description: The user provided Globus token has expired or the user did not supply a valid token.
+        '403':
+          description: The user provided Globus token does not have the desired membership permission to access this resource.
         '404':
           description: The delete operation failed because the key was not found for the user. The Response has a JSON body with one object with an "error" key, and the associated value describes the problem.
         '500':
@@ -144,6 +156,10 @@ paths:
           description: Every key/value pair was created or updated using the JSON array of the Request and the Globus ID of the bearer token. The Response has a JSON body with one object with a "message" key, and the associated value confirms the successful operation
         '400':
           description: Creation or update failed for one or more key/value pairs, so nothing changed in the data store. The Response has a JSON body with one object with an "error" key, and the associated value describes the problem.  Typical causes are keys which have whitespace or disallowed characters, keys which are too long, and invalid JSON in the Request.
+        '401':
+          description: The user provided Globus token has expired or the user did not supply a valid token.
+        '403':
+          description: The user provided Globus token does not have the desired membership permission to access this resource.
         '500':
           description: An internal error occurred, causing the operation to fail, so nothing changed in the data store. Typical of unexpected problems and monitored by IT staff.
     get:
@@ -157,6 +173,10 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/KeyValueArray'
               example: [{"key": "my-stashed-dict", "value": {"my-best-item": "tools", "my-worst-item": "tasks"}}, {"key": "my-stashed-list", "value": ["tools", "tasks", "time"]}]
+        '401':
+          description: The user provided Globus token has expired or the user did not supply a valid token.
+        '403':
+          description: The user provided Globus token does not have the desired membership permission to access this resource.
         '404':
           description: No key/value pairs were found for the Globus ID of the bearer token in the data store. The Response has a JSON body with one object with an "error" key, and the associated value describes the problem.
         '500':
@@ -185,6 +205,10 @@ paths:
               example: [{"key": "keyname1", "value": ["flour","water","salt","yeast"]},{"key": "keyname10", "value": ["wheat", "sourdough"]},{"key": "keyname100", "value": ["oven", "dutch oven", "bowls"]}]
         '400':
           description: The read operation failed. The Response has a JSON body with one array.  Each element of array is an object with an "error" key, and the associated value describes the problem.  Typical causes are keys which have whitespace or disallowed characters, keys which are too long, and invalid JSON in the Request.  Any key specified in the Request that does not have an error message was found in the data store but not returned in the error Response.
+        '401':
+          description: The user provided Globus token has expired or the user did not supply a valid token.
+        '403':
+          description: The user provided Globus token does not have the desired membership permission to access this resource.
         '404':
           description: The read operation failed because at least one specified key was not found for the user. The Response has a JSON body with one object with an "error" key, whose value describes the problem, and one "unfound_keys" key, whose value is an array of unfound keys specified.
         '500':


### PR DESCRIPTION
Defer endpoint access to AWS Gateway configuration rather than using HuBMAP Commons decorator.  Correction will allow any HM users to CRUD key/values.
user-key-value-api#28